### PR TITLE
Fix normalization

### DIFF
--- a/configs/datamodule/predict/word_inference.yaml
+++ b/configs/datamodule/predict/word_inference.yaml
@@ -4,5 +4,6 @@ defaults:
 
 _target_: kwja.datamodule.datasets.word_inference_dataset.WordInferenceDataset
 texts: []
+juman_file: null
 knp_file: null
 doc_id_prefix: null

--- a/src/kwja/callbacks/char_module_writer.py
+++ b/src/kwja/callbacks/char_module_writer.py
@@ -31,7 +31,7 @@ class CharModuleWriter(BasePredictionWriter):
         if use_stdout is True:
             self.destination = sys.stdout
         else:
-            self.destination = Path(f"{output_dir}/{pred_filename}.txt")
+            self.destination = Path(f"{output_dir}/{pred_filename}.juman")
             self.destination.parent.mkdir(exist_ok=True, parents=True)
             if self.destination.exists():
                 os.remove(str(self.destination))

--- a/src/kwja/callbacks/char_module_writer.py
+++ b/src/kwja/callbacks/char_module_writer.py
@@ -7,11 +7,14 @@ from typing import Any, Optional, Sequence, TextIO, Union
 import pytorch_lightning as pl
 import torch
 from pytorch_lightning.callbacks import BasePredictionWriter
+from rhoknp import Morpheme, Sentence
+from rhoknp.units.morpheme import MorphemeAttributes
 
 from kwja.datamodule.datasets import CharDataset, CharInferenceDataset
 from kwja.datamodule.datasets.char_dataset import CharExampleSet
 from kwja.datamodule.datasets.char_inference_dataset import CharInferenceExample
 from kwja.utils.constants import INDEX2SEG_TYPE, INDEX2WORD_NORM_TYPE
+from kwja.utils.sub_document import extract_target_sentences
 from kwja.utils.word_normalize import get_normalized
 
 
@@ -40,8 +43,7 @@ class CharModuleWriter(BasePredictionWriter):
         predictions: Sequence[Any],
         batch_indices: Optional[Sequence[Any]] = None,
     ) -> None:
-        # TODO: Write out results with the original surface form
-        results = []
+        sentences: list[Sentence] = []
         dataloaders = trainer.predict_dataloaders
         for prediction in predictions:
             for batch_pred in prediction:
@@ -76,26 +78,25 @@ class CharModuleWriter(BasePredictionWriter):
                     char_idx = 0
                     document = dataset.doc_id2document[example.doc_id]
                     for sentence in document.sentences:
-                        results.append(sentence.comment)
-                        result: str = ""
+                        Morpheme.count = 0
+                        morphemes: list[Morpheme] = []
                         word_surf: str = ""
                         word_norm_ops: list[str] = []
                         for char in sentence.text:
                             if word_segmenter_types[char_idx] == "B" and word_surf:
-                                if result:
-                                    result += " "
-                                result += get_normalized(word_surf, word_norm_ops, strict=False)
+                                word_norm = get_normalized(word_surf, word_norm_ops, strict=False)
+                                morphemes.append(self.create_morpheme(word_surf, word_norm))
                                 word_surf = ""
                                 word_norm_ops = []
                             word_surf += char
                             word_norm_ops.append(word_normalizer_types[char_idx])
                             char_idx += 1
-                        if result:
-                            result += " "
-                        result += get_normalized(word_surf, word_norm_ops, strict=False)
-                        results.append(result)
+                        word_norm = get_normalized(word_surf, word_norm_ops, strict=False)
+                        morphemes.append(self.create_morpheme(word_surf, word_norm))
+                        sentence.morphemes = morphemes
+                    sentences += extract_target_sentences(document)
 
-        output_string: str = "\n".join(results) + "\n"
+        output_string: str = "".join(sentence.to_jumanpp() for sentence in sentences)
         if isinstance(self.destination, Path):
             self.destination.write_text(output_string)
         elif isinstance(self.destination, TextIOBase):
@@ -112,3 +113,21 @@ class CharModuleWriter(BasePredictionWriter):
         dataloader_idx: int,
     ) -> None:
         pass
+
+    @staticmethod
+    def create_morpheme(surf: str, norm: str) -> Morpheme:
+        return Morpheme(
+            surf,
+            MorphemeAttributes(
+                reading="_",
+                lemma=norm,
+                pos="未定義語",
+                pos_id=15,
+                subpos="その他",
+                subpos_id=1,
+                conjtype="*",
+                conjtype_id=0,
+                conjform="*",
+                conjform_id=0,
+            ),
+        )

--- a/src/kwja/callbacks/word_module_writer.py
+++ b/src/kwja/callbacks/word_module_writer.py
@@ -155,7 +155,6 @@ class WordModuleWriter(BasePredictionWriter):
                     example: Union[WordExampleSet, WordInferenceExample] = dataset.examples[example_id]
                     doc_id = example.doc_id
                     document = dataset.doc_id2document[doc_id]
-                    # TODO: get word-level reading predictions
                     readings = [self.id2reading[pred] for pred in reading_preds]
                     word_reading_preds = get_word_level_readings(readings, tokens.split(" "), reading_subword_map)
                     morphemes = self._create_morphemes(

--- a/src/kwja/callbacks/word_module_writer.py
+++ b/src/kwja/callbacks/word_module_writer.py
@@ -201,7 +201,7 @@ class WordModuleWriter(BasePredictionWriter):
         conjform_preds: list[int],
     ) -> list[Morpheme]:
         morphemes = []
-        for norm, norm, reading, pos_index, subpos_index, conjtype_index, conjform_index in zip(
+        for word, norm, reading, pos_index, subpos_index, conjtype_index, conjform_index in zip(
             words, norms, reading_preds, pos_preds, subpos_preds, conjtype_preds, conjform_preds
         ):
             pos = INDEX2POS_TYPE[pos_index]
@@ -215,7 +215,7 @@ class WordModuleWriter(BasePredictionWriter):
             semantics: dict[str, Union[str, bool]] = {}
             homograph_ops: list[dict[str, Any]] = []
 
-            # create lemma using surf, conjtype and conjform
+            # create lemma using norm, conjtype and conjform
             if conjtype == "*":
                 lemma = norm
             else:
@@ -284,7 +284,7 @@ class WordModuleWriter(BasePredictionWriter):
                 conjform=conjform,
                 conjform_id=conjform_id,
             )
-            morpheme = Morpheme(norm, attributes, SemanticsDict(semantics), FeatureDict(semantics))
+            morpheme = Morpheme(word, attributes, SemanticsDict(semantics), FeatureDict(semantics))
             morphemes.append(morpheme)
             if len(homograph_ops) >= 1:
                 range_list = []
@@ -303,7 +303,7 @@ class WordModuleWriter(BasePredictionWriter):
                         else:
                             raise NotImplementedError
                     morpheme2 = Morpheme(
-                        norm, attributes2, SemanticsDict(semantics2), FeatureDict(semantics2), homograph=True
+                        word, attributes2, SemanticsDict(semantics2), FeatureDict(semantics2), homograph=True
                     )
                     # rhoknp coverts homographs into KNP's ALT features
                     morpheme.homographs.append(morpheme2)

--- a/src/kwja/cli/cli.py
+++ b/src/kwja/cli/cli.py
@@ -51,7 +51,7 @@ def main(
 
     tmp_dir: TemporaryDirectory = TemporaryDirectory()
     typo_path: Path = tmp_dir.name / Path("predict_typo.txt")
-    char_path: Path = tmp_dir.name / Path("predict_char.txt")
+    char_path: Path = tmp_dir.name / Path("predict_char.juman")
     word_path: Path = tmp_dir.name / Path("predict_word.knp")
     word_discourse_path: Path = tmp_dir.name / Path("predict_word_discourse.knp")
 
@@ -130,9 +130,7 @@ def main(
         ],
         devices=1,
     )
-    char_results: list[str] = char_path.read_text().splitlines()
-    comments: list[str] = [x for i, x in enumerate(char_results) if i % 2 == 0]
-    word_cfg.datamodule.predict.texts = [x for i, x in enumerate(char_results) if i % 2 == 1]
+    word_cfg.datamodule.predict.juman_file = char_path
     word_datamodule = DataModule(cfg=word_cfg.datamodule)
     word_datamodule.setup(stage=TrainerFn.PREDICTING)
     word_trainer.predict(model=word_model, dataloaders=word_datamodule.predict_dataloader())
@@ -141,8 +139,6 @@ def main(
     word_module_writer.jumandic.close()
     del word_model
     document: Document = Document.from_knp(word_path.read_text())
-    for idx, sentence in enumerate(document.sentences):
-        sentence.comment = comments[idx]
     # Remove the result of discourse relation analysis by the jointly learned model.
     for base_phrase in document.base_phrases:
         if "談話関係" in base_phrase.features:
@@ -187,8 +183,6 @@ def main(
             dataloaders=word_discourse_datamodule.predict_dataloader(),
         )
         discourse_document: Document = Document.from_knp(word_discourse_path.read_text())
-        for idx, sentence in enumerate(discourse_document.sentences):
-            sentence.comment = comments[idx]
         print(discourse_document.to_knp(), end="")
     tmp_dir.cleanup()
 

--- a/src/kwja/cli/cli.py
+++ b/src/kwja/cli/cli.py
@@ -38,7 +38,7 @@ def main(
     discourse: Optional[bool] = typer.Option(True, help="Whether to perform discourse relation analysis."),
 ) -> None:
     if text is not None and filename is not None:
-        typer.echo("ERROR: Please provide text or filename, not both")
+        typer.echo("ERROR: Please provide text or filename, not both", err=True)
         raise typer.Exit()
     elif text is not None:
         input_texts: list[str] = text.splitlines()
@@ -46,7 +46,7 @@ def main(
         with Path(filename).open() as f:
             input_texts = [line.strip() for line in f]
     else:
-        typer.echo("ERROR: Please provide text or filename")
+        typer.echo("ERROR: Please provide text or filename", err=True)
         raise typer.Exit
 
     tmp_dir: TemporaryDirectory = TemporaryDirectory()

--- a/src/kwja/datamodule/datasets/word_inference_dataset.py
+++ b/src/kwja/datamodule/datasets/word_inference_dataset.py
@@ -44,13 +44,16 @@ class WordInferenceDataset(BaseDataset):
         max_seq_length: int = 512,
         tokenizer_kwargs: dict = None,
         doc_id_prefix: Optional[str] = None,
+        juman_file: Optional[Path] = None,
         knp_file: Optional[Path] = None,
         **_,  # accept reading_resource_path
     ) -> None:
-        if knp_file is None:
-            documents = self._create_documents_from_texts(list(texts), doc_id_prefix)
-        else:
+        if knp_file is not None:
             documents = [Document.from_knp(knp_file.read_text())]
+        elif juman_file is not None:
+            documents = [Document.from_jumanpp(juman_file.read_text())]
+        else:
+            documents = self._create_documents_from_texts(list(texts), doc_id_prefix)
         super().__init__(documents, document_split_stride, model_name_or_path, max_seq_length, tokenizer_kwargs or {})
 
         self.exophora_referents = [ExophoraReferent(s) for s in exophora_referents]

--- a/src/kwja/utils/sub_document.py
+++ b/src/kwja/utils/sub_document.py
@@ -6,8 +6,9 @@ SUB_DOC_PAT: re.Pattern[str] = re.compile(r"^(?P<did>[a-zA-Z\d\-_]+?)-split(?P<s
 
 
 def is_target_sentence(sentence: Sentence) -> bool:
-    document = sentence.document
-    match = SUB_DOC_PAT.match(document.doc_id)
+    if sentence.doc_id is None:
+        return True
+    match = SUB_DOC_PAT.match(sentence.doc_id)
     if match is None:
         return True
     stride = int(match.group("stride"))
@@ -15,7 +16,7 @@ def is_target_sentence(sentence: Sentence) -> bool:
     if idx == 0:
         return True
     else:
-        return sentence in document.sentences[-stride:]
+        return sentence in sentence.document.sentences[-stride:]
 
 
 def extract_target_sentences(document: Document) -> list[Sentence]:

--- a/tests/callbacks/test_char_module_writer.py
+++ b/tests/callbacks/test_char_module_writer.py
@@ -1,4 +1,5 @@
 import tempfile
+import textwrap
 
 import torch
 from omegaconf import ListConfig
@@ -74,4 +75,13 @@ def test_write_on_epoch_end():
             ]
         ]
         writer.write_on_epoch_end(trainer, ..., predictions)
-        assert writer.destination.read_text() == f"# S-ID:test-0-0 kwja:{kwja.__version__}\n今日 は 晴れ だ\n"
+        assert writer.destination.read_text() == textwrap.dedent(
+            f"""\
+            # S-ID:test-0-0 kwja:{kwja.__version__}
+            今日 _ 今日 未定義語 15 その他 1 * 0 * 0
+            は _ は 未定義語 15 その他 1 * 0 * 0
+            晴れ _ 晴れ 未定義語 15 その他 1 * 0 * 0
+            だぁ _ だ 未定義語 15 その他 1 * 0 * 0
+            EOS
+            """
+        )


### PR DESCRIPTION
## What

This PR fixes the issue in writing out the result of word normalization. Now, the output will be like:

```shell
$ kwja --text "祭りだーー"
# S-ID:202210031226-0-0 kwja:0.1.0
* -1D
+ -1D <rel type="ガ" target="不特定:物"/><用言:判><体言><時制:非過去><節-区切><レベル:C><状態述語><節-主辞>
祭り まつり 祭り 名詞 6 普通名詞 1 * 0 * 0 "代表表記:祭り/まつりv ドメイン:文化・芸術 連用形名詞化:祭る/まつる" <代表表記:祭り/まつりv><ドメイン:文化・芸術><連用形名詞化:祭る/まつる><基本句-主辞><用言表記先頭><用言表記末尾>
だーー だーー だ 判定詞 4 * 0 判定詞 25 基本形 2
EOS
```
