### PR TITLE
Fix Windows support: file encoding, test symlink, and pure-cdb install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,11 @@ dependencies = [
     "rhoknp>=1.7",
     "typer-slim>=0.24.0,<0.25.0",
     "jinf>=1.0.4",
-    "pure-cdb>=4.0",
+    # pure-cdb 4.x publishes manylinux x86_64 wheels only, and building its C extension from
+    # the sdist fails on Windows (setuptools cannot detect a modern MSVC install). Fall back to
+    # the last pure-Python release there; everywhere else keep 4.x and its accelerated hashing.
+    "pure-cdb>=4.0; sys_platform != 'win32'",
+    "pure-cdb==3.1.0; sys_platform == 'win32'",
     "rich>=14.0.0,<15.0.0",
     "pyyaml>=6.0",
     "regex>=2024.7.24",

--- a/src/kwja/callbacks/base_module_writer.py
+++ b/src/kwja/callbacks/base_module_writer.py
@@ -22,7 +22,7 @@ class BaseModuleWriter(BasePredictionWriter):
 
     def write_output_string(self, output_string: str) -> None:
         if isinstance(self.destination, Path):
-            with self.destination.open(mode="a") as f:
+            with self.destination.open(mode="a", encoding="utf-8") as f:
                 f.write(output_string)
         elif isinstance(self.destination, TextIOBase):
             self.destination.write(output_string)

--- a/src/kwja/cli/cli.py
+++ b/src/kwja/cli/cli.py
@@ -128,7 +128,7 @@ class TypoModuleProcessor(BaseModuleProcessor):
 
     def export_prediction(self) -> str:
         output_text = ""
-        for line in self.destination.read_text().strip().split("\n"):
+        for line in self.destination.read_text(encoding="utf-8").strip().split("\n"):
             if line.startswith("# D-ID:"):
                 pass
             else:
@@ -155,7 +155,7 @@ class CharModuleProcessor(BaseModuleProcessor):
 
     def export_prediction(self) -> str:
         export_text = ""
-        with self.destination.open() as f:
+        with self.destination.open(encoding="utf-8") as f:
             for juman_text in chunk_by_sentence(f):
                 sentence = Sentence.from_jumanpp(juman_text)
                 if sentence.comment != "":
@@ -182,7 +182,7 @@ class Seq2SeqModuleProcessor(BaseModuleProcessor):
         return datamodule
 
     def export_prediction(self) -> str:
-        return self.destination.read_text()
+        return self.destination.read_text(encoding="utf-8")
 
 
 class WordModuleProcessor(BaseModuleProcessor):
@@ -210,7 +210,7 @@ class WordModuleProcessor(BaseModuleProcessor):
         return datamodule
 
     def export_prediction(self) -> str:
-        return self.destination.read_text()
+        return self.destination.read_text(encoding="utf-8")
 
 
 class CLIProcessor:
@@ -248,9 +248,11 @@ class CLIProcessor:
             for input_document in input_documents:
                 output_text += f"# D-ID:{input_document.doc_id}\n"
                 output_text += normalize_text(input_document.text) + "\nEOD\n"
-            self.initial_destination.write_text(output_text)
+            self.initial_destination.write_text(output_text, encoding="utf-8")
         elif self.processors[0].input_format == InputFormat.JUMANPP:
-            self.initial_destination.write_text("".join(document.to_jumanpp() + "\n" for document in input_documents))
+            self.initial_destination.write_text(
+                "".join(document.to_jumanpp() + "\n" for document in input_documents), encoding="utf-8"
+            )
         else:
             raise AssertionError  # unreachable
 
@@ -387,7 +389,7 @@ def main(  # noqa: PLR0917
             if path.exists() is False:
                 logger.error(f"ERROR: {path} does not exist")
                 raise typer.Abort
-            with path.open() as f:
+            with path.open(encoding="utf-8") as f:
                 for document_text in _chunk_by_document(f, input_format):
                     input_documents.append(_load_document_from_text(document_text, input_format))
     else:

--- a/src/kwja/cli/config.py
+++ b/src/kwja/cli/config.py
@@ -45,7 +45,7 @@ class CLIConfig:
 
     @classmethod
     def from_yaml(cls, path: Path) -> "CLIConfig":
-        config = yaml.safe_load(path.read_text())
+        config = yaml.safe_load(path.read_text(encoding="utf-8"))
         return cls(
             model_size=ModelSize(config["model_size"]),
             device=Device(config["device"]),

--- a/src/kwja/datamodule/datasets/base.py
+++ b/src/kwja/datamodule/datasets/base.py
@@ -84,7 +84,7 @@ class FullAnnotatedDocumentLoaderMixin:
 
     @staticmethod
     def _load_document(path: Path) -> Document:
-        return Document.from_knp(path.read_text())
+        return Document.from_knp(path.read_text(encoding="utf-8"))
 
     def _postprocess_document(self, document: Document) -> Document:
         return document

--- a/src/kwja/datamodule/datasets/char_inference.py
+++ b/src/kwja/datamodule/datasets/char_inference.py
@@ -30,7 +30,7 @@ class CharInferenceDataset(BaseDataset[CharInferenceExample, CharModuleFeatures]
         if len(texts) > 0:
             documents = create_documents_from_raw_texts(texts)
         elif raw_text_file is not None:
-            with raw_text_file.open() as f:
+            with raw_text_file.open(encoding="utf-8") as f:
                 documents = create_documents_from_raw_texts(chunk_by_document(f))
         else:
             documents = []

--- a/src/kwja/datamodule/datasets/seq2seq.py
+++ b/src/kwja/datamodule/datasets/seq2seq.py
@@ -49,7 +49,7 @@ class Seq2SeqDataset(BaseDataset[Seq2SeqExample, Seq2SeqModuleFeatures]):
     def _load_documents(document_dir: Path, ext: str = "knp") -> list[Document]:
         documents = []
         for path in track(sorted(document_dir.glob(f"*.{ext}")), description="Loading documents"):
-            documents.append(Document.from_knp(path.read_text()))
+            documents.append(Document.from_knp(path.read_text(encoding="utf-8")))
         return documents
 
     def _load_examples(self, documents: list[Document], is_train: bool) -> list[Seq2SeqExample]:

--- a/src/kwja/datamodule/datasets/seq2seq_inference.py
+++ b/src/kwja/datamodule/datasets/seq2seq_inference.py
@@ -30,7 +30,7 @@ class Seq2SeqInferenceDataset(BaseDataset[Seq2SeqInferenceExample, Seq2SeqModule
         self.formatter: Seq2SeqFormatter = Seq2SeqFormatter(tokenizer)
 
         if juman_file is not None:
-            with juman_file.open() as f:
+            with juman_file.open(encoding="utf-8") as f:
                 documents = [
                     Document.from_jumanpp(c) for c in track(chunk_by_document(f), description="Loading documents")
                 ]

--- a/src/kwja/datamodule/datasets/typo.py
+++ b/src/kwja/datamodule/datasets/typo.py
@@ -18,7 +18,7 @@ MULTI_CHAR_VOCAB_TRAVERSABLE = RESOURCE_TRAVERSABLE / "typo_correction" / "multi
 def get_maps(tokenizer: PreTrainedTokenizerBase) -> tuple[dict[str, int], dict[int, str]]:
     token2token_id = tokenizer.get_vocab()
     with as_file(MULTI_CHAR_VOCAB_TRAVERSABLE) as path:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 if line := line.strip():
                     token2token_id[line] = len(token2token_id.keys())
@@ -60,7 +60,7 @@ class TypoDataset(BaseDataset[TypoExample, TypoModuleFeatures]):
         examples: list[TypoExample] = []
         example_id = 0
         for path in track(sorted(example_dir.glob("**/*.jsonl")), description="Loading documents"):
-            for line in path.read_text().strip().split("\n"):
+            for line in path.read_text(encoding="utf-8").strip().split("\n"):
                 examples.append(TypoExample(**json.loads(line), example_id=example_id, doc_id=""))
                 example_id += 1
         return examples

--- a/src/kwja/datamodule/datasets/typo_inference.py
+++ b/src/kwja/datamodule/datasets/typo_inference.py
@@ -27,7 +27,7 @@ class TypoInferenceDataset(BaseDataset[TypoInferenceExample, TypoModuleFeatures]
         if len(texts) > 0:
             documents = create_documents_from_raw_texts(texts)
         elif raw_text_file is not None:
-            with raw_text_file.open() as f:
+            with raw_text_file.open(encoding="utf-8") as f:
                 documents = create_documents_from_raw_texts(chunk_by_document(f))
         else:
             documents = []

--- a/src/kwja/datamodule/datasets/word.py
+++ b/src/kwja/datamodule/datasets/word.py
@@ -324,7 +324,7 @@ class WordDataset(BaseDataset[WordExample, WordModuleFeatures], FullAnnotatedDoc
             discourse_path = self.path / "disc_crowd" / f"{document.doc_id}.knp"
         if discourse_path.exists():
             try:
-                discourse_document = Document.from_knp(discourse_path.read_text())
+                discourse_document = Document.from_knp(discourse_path.read_text(encoding="utf-8"))
                 if document == discourse_document:
                     return discourse_document
             except AssertionError:

--- a/src/kwja/datamodule/datasets/word_inference.py
+++ b/src/kwja/datamodule/datasets/word_inference.py
@@ -37,7 +37,7 @@ class WordInferenceDataset(BaseDataset[WordInferenceExample, WordModuleFeatures]
     ) -> None:
         super().__init__(tokenizer, max_seq_length)
         if juman_file is not None:
-            with juman_file.open() as f:
+            with juman_file.open(encoding="utf-8") as f:
                 documents = [
                     Document.from_jumanpp(c) for c in track(chunk_by_document(f), description="Loading documents")
                 ]

--- a/src/kwja/modules/typo.py
+++ b/src/kwja/modules/typo.py
@@ -32,8 +32,8 @@ class TypoModule(BaseModule[TypoModuleMetric]):
 
         self.kdr_tagger = SequenceLabelingHead(self.encoder.config.vocab_size, **head_kwargs)
         vocab_traversable = RESOURCE_TRAVERSABLE / "typo_correction" / "multi_char_vocab.txt"
-        with as_file(vocab_traversable) as file_path:
-            extended_vocab_size = sum(1 for _ in open(file_path))
+        with as_file(vocab_traversable) as file_path, open(file_path, encoding="utf-8") as f:
+            extended_vocab_size = sum(1 for _ in f)
         self.ins_tagger = SequenceLabelingHead(self.encoder.config.vocab_size + extended_vocab_size, **head_kwargs)
 
     def setup(self, stage: str) -> None:

--- a/src/kwja/utils/jumandic.py
+++ b/src/kwja/utils/jumandic.py
@@ -17,7 +17,9 @@ class JumanDic:
     def __init__(self, dic_dir: Path | Traversable) -> None:
         self.jumandic = cdblib.Reader(dic_dir.joinpath("jumandic.db").read_bytes())
         self.jumandic_canon = cdblib.Reader(dic_dir.joinpath("jumandic_canon.db").read_bytes())
-        self.grammar_data: dict[str, list[str]] = json.loads(dic_dir.joinpath("grammar.json").read_text())
+        self.grammar_data: dict[str, list[str]] = json.loads(
+            dic_dir.joinpath("grammar.json").read_text(encoding="utf-8")
+        )
 
     def lookup_by_norm(self, surf: str) -> list[dict[str, str]]:
         buf = self.jumandic.get(surf.encode("utf-8"))
@@ -134,5 +136,6 @@ class JumanDic:
                     "id2semantics": _build_reverse_lookup(semantics2id),
                 },
                 ensure_ascii=False,
-            )
+            ),
+            encoding="utf-8",
         )

--- a/src/kwja/utils/kanjidic.py
+++ b/src/kwja/utils/kanjidic.py
@@ -297,7 +297,7 @@ class KanjiDic:
             self._parse(fpath)
 
     def _parse(self, path: Path) -> None:
-        with open(path) as fp:
+        with open(path, encoding="utf-8") as fp:
             for line in fp:
                 if len(line) <= 0 or line[0] == "#":
                     continue

--- a/src/kwja/utils/reading_prediction.py
+++ b/src/kwja/utils/reading_prediction.py
@@ -34,7 +34,7 @@ READING_VOCAB_TRAVERSABLE = RESOURCE_TRAVERSABLE / "reading_prediction" / "vocab
 def get_reading2reading_id() -> dict[str, int]:
     reading2reading_id = {UNK: UNK_ID, ID: ID_ID}
     with as_file(READING_VOCAB_TRAVERSABLE) as path:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 if line := line.strip():
                     if line not in reading2reading_id:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -9,7 +10,12 @@ from transformers import AutoTokenizer, PreTrainedTokenizerBase
 os.environ["DATA_DIR"] = ""
 base_path = Path(__file__).parent.parent / "configs" / "base.yaml"
 if base_path.exists() is False:
-    base_path.symlink_to(base_path.parent / "base_template.yaml")
+    try:
+        base_path.symlink_to(base_path.parent / "base_template.yaml")
+    except OSError:
+        # Windows既定ではシンボリックリンク作成に管理者権限/開発者モードが必要なため、
+        # 権限が無い環境ではコピーにフォールバックする(内容は読み取り専用で使うだけなので実害無し)
+        shutil.copy(base_path.parent / "base_template.yaml", base_path)
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -679,7 +682,8 @@ name = "ipython"
 version = "8.39.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -704,8 +708,10 @@ name = "ipython"
 version = "9.15.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -803,7 +809,8 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "omegaconf" },
-    { name = "pure-cdb" },
+    { name = "pure-cdb", version = "3.1.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "pure-cdb", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
     { name = "pyyaml" },
     { name = "regex" },
     { name = "rhoknp" },
@@ -855,7 +862,8 @@ requires-dist = [
     { name = "lightning", specifier = ">=2.6.0,<2.7.0" },
     { name = "numpy", specifier = ">=2.0,<2.5" },
     { name = "omegaconf", specifier = ">=2.3.0,<2.4.0" },
-    { name = "pure-cdb", specifier = ">=4.0" },
+    { name = "pure-cdb", marker = "sys_platform != 'win32'", specifier = ">=4.0" },
+    { name = "pure-cdb", marker = "sys_platform == 'win32'", specifier = "==3.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "regex", specifier = ">=2024.7.24" },
     { name = "rhoknp", specifier = ">=1.7" },
@@ -1220,7 +1228,8 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -1232,8 +1241,10 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -1245,7 +1256,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -1310,8 +1322,10 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -1783,8 +1797,27 @@ wheels = [
 
 [[package]]
 name = "pure-cdb"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/8a/8f06116e4add0e1e48f65483851ca044a7a3a8d7ba96d9063ebcb44f6977/pure-cdb-3.1.0.tar.gz", hash = "sha256:d919258e581496ecd45c6ba24c76bdddf4134f91edd3bb42d06bf718b0aeba33", size = 8357, upload-time = "2019-09-21T18:00:41.334Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/b5/c07116dea95eff648405925ef2d3922ac1a9183c106c2de51c8c2ab3d726/pure_cdb-3.1.0-py3-none-any.whl", hash = "sha256:98dcd6ca4e327883b0e166741effcce7d17e8fd609a45970ba53371e452cf6bd", size = 10453, upload-time = "2019-09-21T18:00:39.226Z" },
+]
+
+[[package]]
+name = "pure-cdb"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/e6/af/adf9488f26ef1f0cf6e3ea80ca3581c8a227a98b167638e05d9d962dd320/pure-cdb-4.0.0.tar.gz", hash = "sha256:8c44801e281f029769ef1cf2a53cfeec67bc962d595b83365c0463daea95b08c", size = 10371, upload-time = "2022-09-03T12:26:01.702Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/59/0d53c70d52b7e566433a7c03921b0388e27a2b2aeaae5951c9a74301cdf3/pure_cdb-4.0.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f78d336bf18dbc0997879a95cbd854536176810af262d13486145273584a5528", size = 18299, upload-time = "2022-09-03T12:35:11.908Z" },
@@ -2277,7 +2310,8 @@ name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "joblib" },
@@ -2319,8 +2353,10 @@ name = "scikit-learn"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "joblib" },
@@ -2357,7 +2393,8 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
@@ -2416,7 +2453,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.11.*'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
@@ -2470,7 +2508,8 @@ name = "scipy"
 version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },


### PR DESCRIPTION
Three independent problems that together make KWJA unusable on a stock Japanese Windows machine. Each is a separate commit.

## 1. Text file I/O relies on the locale encoding

Every site that reads or writes text — the bundled resources (reading vocabulary, kanjidic, typo-correction vocab, jumandic grammar data), the CLI's `--filename` input and exported predictions, and the KNP/Jumanpp document loaders — calls `open()` / `Path.read_text()` / `Path.write_text()` without an encoding, so Python falls back to the platform's locale encoding. On Japanese Windows that is **cp932**, and loading fails outright:

```
UnicodeDecodeError: 'cp932' codec can't decode byte 0x8d in position 25: illegal multibyte sequence
  File ".../kwja/utils/reading_prediction.py", line 38, in get_reading2reading_id
```

and, once that one is fixed, again at `JumanDic`'s `grammar.json`.

This is already known indirectly: the Windows job in `.github/workflows/test.yml` exports `PYTHONUTF8=1` before running pytest. That keeps CI green, but it does not help anyone actually running `kwja` on Windows.

All of these files are authored and consumed as UTF-8 on every platform, so passing `encoding="utf-8"` is unconditionally correct, and a no-op on Linux/macOS where the locale encoding is already UTF-8.

This commit also closes a leaked file handle in `modules/typo.py`, which opened the vocab file to count its lines without closing it.

## 2. `tests/conftest.py` cannot create its symlink

`conftest.py` symlinks `configs/base.yaml` at import time. Creating a symlink on Windows requires administrator rights or Developer Mode, so on an ordinary checkout this raises `OSError: [WinError 1314]` during collection and **no test runs at all**. Since the file is only ever read, the commit falls back to copying it when the OS refuses the symlink.

## 3. `pure-cdb` cannot be installed on Windows

`pure-cdb` 4.x publishes manylinux x86_64 wheels only. Everywhere else pip falls back to its sdist, which builds a C extension — and on Windows that fails with `error: Unable to find a compatible Visual Studio installation` even with VS2022 and its C++ tooling installed, because setuptools' MSVC detection does not recognise it.

The commit selects the last pure-Python release (3.1.0) there via an environment marker. Platforms that do get a wheel stay on 4.x and keep its accelerated hashing, so this costs nothing outside Windows. I checked that 3.1.0 still satisfies how KWJA uses `cdblib` — `Reader` over bytes, and `Writer` as a context manager in `JumanDic.build` — and round-trip tested it.

## Verification

On Windows 11 (locale `cp932`), following the CI recipe:

```
uv run --frozen --no-dev --group test pytest -v ./tests
1386 passed in 424.21s
```

`ruff check` / `ruff format --check` report exactly the same 3 pre-existing findings as `dev` does, i.e. nothing new.

## Remaining: one problem is outside this repository

With these changes, the only remaining `UnicodeDecodeError` when running without `PYTHONUTF8` comes from the `jinf` dependency, reached via `word_module_writer.py:54`:

```
FRAME=.../kwja/callbacks/word_module_writer.py:54
FRAME=.../site-packages/jinf/jinf.py:14
```

`jinf` reads its own bundled JSON dictionaries without an encoding, exactly as above. I have opened hkiyomaru/jinf#2 for it. Until that is released, Windows users still need `PYTHONUTF8=1` — but every site inside KWJA itself is fixed by this PR.