### PR TITLE
Cache the predict-time tokenizer to speed up sentence-by-sentence inference

### DIFF
--- a/src/kwja/datamodule/datamodule.py
+++ b/src/kwja/datamodule/datamodule.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import fields, is_dataclass
 from typing import Any
 
@@ -5,7 +6,7 @@ import hydra
 import lightning as L
 import torch
 from lightning.pytorch.trainer.states import TrainerFn
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from torch import Tensor
 from torch.utils.data import ConcatDataset, DataLoader, Dataset
 
@@ -20,6 +21,19 @@ from kwja.datamodule.datasets import (
     WordInferenceDataset,
 )
 from kwja.utils.constants import IGNORE_INDEX
+
+# Process-wide cache of instantiated tokenizers, keyed by their resolved config.
+# A new DataModule is built for every prediction, so without this the tokenizer is
+# rebuilt from scratch on each setup() call even though its config never changes.
+# Only used for the PREDICTING stage; training paths are unaffected.
+_TOKENIZER_CACHE: dict[str, Any] = {}
+
+
+def _instantiate_tokenizer_cached(tokenizer_cfg: DictConfig) -> Any:
+    key = json.dumps(OmegaConf.to_container(tokenizer_cfg, resolve=True), sort_keys=True, default=str)
+    if key not in _TOKENIZER_CACHE:
+        _TOKENIZER_CACHE[key] = hydra.utils.instantiate(tokenizer_cfg)
+    return _TOKENIZER_CACHE[key]
 
 
 class DataModule(L.LightningDataModule):
@@ -53,7 +67,11 @@ class DataModule(L.LightningDataModule):
         if stage == TrainerFn.TESTING:
             self.test_datasets = {corpus: hydra.utils.instantiate(config) for corpus, config in self.cfg.test.items()}
         if stage == TrainerFn.PREDICTING:
-            self.predict_dataset = hydra.utils.instantiate(self.cfg.predict)
+            if "tokenizer" in self.cfg.predict:
+                tokenizer = _instantiate_tokenizer_cached(self.cfg.predict.tokenizer)
+                self.predict_dataset = hydra.utils.instantiate(self.cfg.predict, tokenizer=tokenizer)
+            else:
+                self.predict_dataset = hydra.utils.instantiate(self.cfg.predict)
 
     def train_dataloader(self) -> DataLoader:
         assert self.train_dataset is not None

--- a/tests/datamodule/test_datamodule.py
+++ b/tests/datamodule/test_datamodule.py
@@ -1,0 +1,83 @@
+from omegaconf import DictConfig, OmegaConf
+
+import kwja.datamodule.datamodule as datamodule_module
+from kwja.datamodule.datamodule import DataModule
+
+# Any tokenizer works here; this one is small and already used by the other tests.
+TOKENIZER_NAME = "ku-nlp/deberta-v2-tiny-japanese-char-wwm"
+
+
+def _build_cfg() -> DictConfig:
+    return OmegaConf.create(
+        {
+            "predict": {
+                "_target_": "kwja.datamodule.datasets.CharInferenceDataset",
+                "texts": ["今日は晴れだ。散歩に行こう。"],
+                "max_seq_length": 512,
+                "tokenizer": {
+                    "_target_": "transformers.AutoTokenizer.from_pretrained",
+                    "pretrained_model_name_or_path": TOKENIZER_NAME,
+                    "do_word_tokenize": False,
+                    "_convert_": "all",
+                },
+            },
+            "batch_size": 1,
+            "num_workers": 0,
+            "dataset_type": "char",
+        }
+    )
+
+
+def test_setup_predicting() -> None:
+    datamodule_module._TOKENIZER_CACHE.clear()
+    datamodule = DataModule(_build_cfg())
+    datamodule.setup(stage="predict")
+    assert datamodule.predict_dataset is not None
+    assert len(datamodule.predict_dataset) == 1
+
+
+def test_tokenizer_is_reused_across_datamodules() -> None:
+    """A new DataModule is built for every prediction, so the tokenizer must be shared."""
+    datamodule_module._TOKENIZER_CACHE.clear()
+    cfg = _build_cfg()
+
+    first = DataModule(cfg)
+    first.setup(stage="predict")
+    second = DataModule(cfg)
+    second.setup(stage="predict")
+
+    assert first.predict_dataset.tokenizer is second.predict_dataset.tokenizer
+
+
+def test_different_tokenizer_configs_are_not_shared() -> None:
+    """The cache is keyed by the resolved config, so a different config must not hit it."""
+    datamodule_module._TOKENIZER_CACHE.clear()
+
+    default = DataModule(_build_cfg())
+    default.setup(stage="predict")
+
+    modified = _build_cfg()
+    modified.predict.tokenizer.additional_special_tokens = ["[NULL]"]
+    other = DataModule(modified)
+    other.setup(stage="predict")
+
+    assert default.predict_dataset.tokenizer is not other.predict_dataset.tokenizer
+
+
+def test_setup_predicting_without_tokenizer_config() -> None:
+    """A predict config that carries no tokenizer is instantiated as-is."""
+    datamodule_module._TOKENIZER_CACHE.clear()
+    cfg = OmegaConf.create(
+        {
+            "predict": {"_target_": "builtins.dict", "answer": 42},
+            "batch_size": 1,
+            "num_workers": 0,
+            "dataset_type": "char",
+        }
+    )
+
+    datamodule = DataModule(cfg)
+    datamodule.setup(stage="predict")
+
+    assert datamodule.predict_dataset == {"answer": 42}
+    assert not datamodule_module._TOKENIZER_CACHE


### PR DESCRIPTION
## Problem

`CLIProcessor` builds a fresh `DataModule` for every prediction (`_load_datamodule`), and `DataModule.setup()` re-instantiates the whole predict dataset from its Hydra config each time — which recursively calls `AutoTokenizer.from_pretrained()` again.

When analysing text one sentence at a time in a single process, that rebuild ends up costing more per call than the forward pass itself. I found it with `cProfile` while looking into why per-sentence latency was much higher than the model size suggested: the tokenizer reconstruction accounted for a larger share of each call than the actual `nn.Module` work.

The tokenizer sub-config (pretrained model path plus special tokens) is identical across those calls — only the input text differs — so the work is entirely redundant.

## Change

Cache the instantiated tokenizer keyed by its resolved config, and pass it to `instantiate()` as an override, which also stops Hydra rebuilding that subtree.

Scoped to the `PREDICTING` stage; the `FITTING` / `VALIDATING` / `TESTING` setup paths used for training are untouched.

Sharing a single instance is safe here because nothing mutates the tokenizer. The one caller that could — `datasets/typo.py`'s `get_maps()` — mutates the dict returned by `get_vocab()`, and I verified that is a fresh copy on each call rather than a live view of internal state.

## Measurements

tiny / CPU / Windows, `HF_HUB_OFFLINE=1`, five sequential single-sentence predictions in one process, toggling only this change:

| | 1st | 2nd | 3rd | 4th | 5th |
|---|---|---|---|---|---|
| before | 458ms | 266ms | 260ms | 263ms | 246ms |
| after | 462ms | 158ms | 172ms | 165ms | 165ms |

Roughly a third off every call after the first. The first call is unchanged, as expected — that is where the tokenizer is actually built.

## Correctness

`tests/` currently has no coverage of `DataModule.setup()`, so a green test run does not say much about this change on its own. I checked equivalence directly instead: with and without the cache, the analyser produces **byte-identical output** across six sentences (119 lines / 7650 bytes), once the timestamp inside auto-generated sentence IDs is normalised.

The full suite also passes on Windows: `1386 passed`. `ruff check` / `format --check` report the same 3 pre-existing findings as `dev`, i.e. nothing new.

Note: to run the suite on Windows at all I needed the fixes in #251; this branch itself is independent of that one and touches only `datamodule.py`.