### PR TITLE
Explicitly UTF-8-encode text file I/O in tests and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ You can read a KNP format file with [rhoknp](https://github.com/ku-nlp/rhoknp).
 
 ```python
 from rhoknp import Document
+
 with open("analyzed.knp") as f:
     parsed_document = Document.from_knp(f.read())
 ```
@@ -139,6 +140,7 @@ Perform language analysis with the `kwja` instance:
 
 ```python
 from rhoknp import KWJA
+
 kwja = KWJA()
 analyzed_document = kwja.apply(
     "KWJAは日本語の統合解析ツールです。汎用言語モデルを利用し、様々な言語解析を統一的な方法で解いています。"

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -70,7 +70,9 @@ def main(eval_cfg: DictConfig) -> None:
             cfg.datamodule.predict.raw_text_file = Path(raw_input_file)
         else:
             # For typo module and char module
-            Path(temp_file.name).write_text("\n".join(normalize_text(line) for line in sys.stdin.readlines()))
+            Path(temp_file.name).write_text(
+                "\n".join(normalize_text(line) for line in sys.stdin.readlines()), encoding="utf-8"
+            )
             cfg.datamodule.predict.raw_text_file = Path(temp_file.name)
 
         datamodule = DataModule(cfg=cfg.datamodule)

--- a/scripts/build_dataset.py
+++ b/scripts/build_dataset.py
@@ -315,7 +315,7 @@ def assign_features_and_save(
         except Exception as e:
             logger.warning(f"{type(e).__name__}: {e}, {document.doc_id}")
             knp = KNP(options=["-tab", "-dpnd-fast", "-read-feature"])
-            Path(f"knp_error_{document.doc_id}.knp").write_text(document.to_knp())
+            Path(f"knp_error_{document.doc_id}.knp").write_text(document.to_knp(), encoding="utf-8")
             continue
 
         assert len(document.to_knp().split("\n")) == len(knp_text.split("\n")), (
@@ -343,7 +343,7 @@ def assign_features_and_save(
 
         doc_id = document.doc_id
         split = doc_id2split[doc_id]
-        output_root.joinpath(f"{split}/{doc_id}.knp").write_text(document.to_knp())
+        output_root.joinpath(f"{split}/{doc_id}.knp").write_text(document.to_knp(), encoding="utf-8")
 
 
 def test_jumanpp_version() -> None:
@@ -516,11 +516,11 @@ def main() -> None:
 
     knp_texts = []
     for input_file in Path(args.INPUT).glob("**/*.knp"):
-        with input_file.open(mode="r") as f:
+        with input_file.open(mode="r", encoding="utf-8") as f:
             knp_texts += [knp_text for knp_text in chunk_by_document(f, doc_id_format=args.doc_id_format)]
 
     if args.ne_tags:
-        with open(args.ne_tags) as f:
+        with open(args.ne_tags, encoding="utf-8") as f:
             sentences = [Sentence.from_jumanpp(jumanpp_text) for jumanpp_text in chunk_by_sentence(f)]
         sid2tagged_sentence = {sentence.sid: sentence for sentence in sentences}
     else:
@@ -536,7 +536,7 @@ def main() -> None:
             continue
         split = "valid" if id_file.stem == "dev" else id_file.stem
         output_root.joinpath(split).mkdir(parents=True, exist_ok=True)
-        for doc_id in id_file.read_text().splitlines():
+        for doc_id in id_file.read_text(encoding="utf-8").splitlines():
             doc_id2split[doc_id] = split
 
     if args.j > 0:

--- a/scripts/count_rel_types.py
+++ b/scripts/count_rel_types.py
@@ -29,7 +29,7 @@ def load_documents(paths: list[Path]) -> list[Document]:
 
 
 def load_document(path: Path) -> Document:
-    return Document.from_knp(path.read_text())
+    return Document.from_knp(path.read_text(encoding="utf-8"))
 
 
 def count_cases(documents: list[Document]) -> dict[str, int]:

--- a/scripts/eval_jumanpp_knp.py
+++ b/scripts/eval_jumanpp_knp.py
@@ -69,7 +69,7 @@ def main() -> None:
     for corpus in CORPORA:
         knp_dir = Path(sys.argv[1]) / corpus / "test"
         metrics, num_docs = evaluate_docs(
-            [Document.from_knp(knp_path.read_text()) for knp_path in knp_dir.glob("*.knp")]
+            [Document.from_knp(knp_path.read_text(encoding="utf-8")) for knp_path in knp_dir.glob("*.knp")]
         )
         print(corpus, num_docs, metrics)
 

--- a/scripts/preprocessors/preprocess_canon.py
+++ b/scripts/preprocessors/preprocess_canon.py
@@ -87,7 +87,7 @@ def main() -> None:
     canon2freq: dict[str, int] = {}
     excluded_nums: dict[str, int] = {}
     for input_path in tqdm(input_paths):
-        with input_path.open() as f:
+        with input_path.open(encoding="utf-8") as f:
             for knp in chunk_by_sentence(f):
                 try:
                     sentence: Sentence = Sentence.from_knp(knp)
@@ -187,20 +187,20 @@ def main() -> None:
     output_dir: Path = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(output_dir / "canon2freq.txt", "w") as f:
+    with open(output_dir / "canon2freq.txt", "w", encoding="utf-8") as f:
         for canon, freq in canon2freq.items():
             f.write(f"{canon}\t{freq}\n")
-    with open(output_dir / "sampled2freq.txt", "w") as f:
+    with open(output_dir / "sampled2freq.txt", "w", encoding="utf-8") as f:
         for canon, freq in sampled_canon2freq.items():
             f.write(f"{canon}\t{freq}\n")
-    output_dir.joinpath("info.json").write_text(json.dumps(sid2info, indent=2, ensure_ascii=False))
+    output_dir.joinpath("info.json").write_text(json.dumps(sid2info, indent=2, ensure_ascii=False), encoding="utf-8")
 
     train_dir: Path = output_dir / "train"
     if train_dir.exists():
         shutil.rmtree(str(train_dir))
     train_dir.mkdir(exist_ok=True)
     for name, knp_str in train_list:
-        with (train_dir / f"{name}.knp").open("w") as f:
+        with (train_dir / f"{name}.knp").open("w", encoding="utf-8") as f:
             f.write(f"{knp_str}\n")
 
     valid_dir: Path = output_dir / "valid"
@@ -208,7 +208,7 @@ def main() -> None:
         shutil.rmtree(str(valid_dir))
     valid_dir.mkdir(exist_ok=True)
     for name, knp_str in valid_list:
-        with (valid_dir / f"{name}.knp").open("w") as f:
+        with (valid_dir / f"{name}.knp").open("w", encoding="utf-8") as f:
             f.write(f"{knp_str}\n")
 
     test_dir: Path = output_dir / "test"
@@ -216,7 +216,7 @@ def main() -> None:
         shutil.rmtree(str(test_dir))
     test_dir.mkdir(exist_ok=True)
     for name, knp_str in test_list:
-        with (test_dir / f"{name}.knp").open("w") as f:
+        with (test_dir / f"{name}.knp").open("w", encoding="utf-8") as f:
             f.write(f"{knp_str}\n")
 
     print(f"train: {len(train_list)}")

--- a/scripts/preprocessors/preprocess_jumandic.py
+++ b/scripts/preprocessors/preprocess_jumandic.py
@@ -44,7 +44,7 @@ def main() -> None:
     else:
         outdir.mkdir(parents=True)
 
-    with input_path.open() as f:
+    with input_path.open(encoding="utf-8") as f:
         dicreader = csv.reader(f)
         rows = list(dicreader)
 

--- a/scripts/preprocessors/preprocess_norm.py
+++ b/scripts/preprocessors/preprocess_norm.py
@@ -33,7 +33,7 @@ def main() -> None:
 
     partials: list[dict[str, str]] = []
     partial: dict[str, str] = {}
-    with Path(args.input_orig_path).open() as f:
+    with Path(args.input_orig_path).open(encoding="utf-8") as f:
         for line in f:
             if line := line.rstrip("\n"):
                 if line.startswith("\t"):
@@ -60,7 +60,7 @@ def main() -> None:
     sid2knp_str: dict[str, str] = {}
     sid2info: dict[str, dict[int, dict[str, str]]] = {}
     excluded_nums: dict[str, int] = {}
-    with Path(args.input_juman_path).open() as f:
+    with Path(args.input_juman_path).open(encoding="utf-8") as f:
         document: Document = Document.from_jumanpp(f.read())
         for sentence_idx, sentence in enumerate(tqdm(document.sentences)):
             if sentence.text != partials[sentence_idx]["text"]:
@@ -122,7 +122,7 @@ def main() -> None:
     output_dir: Path = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(output_dir / "info.json", "w") as f:
+    with open(output_dir / "info.json", "w", encoding="utf-8") as f:
         json.dump(sid2info, f, indent=2, ensure_ascii=False)
 
     train_dir: Path = output_dir / "train"
@@ -130,7 +130,7 @@ def main() -> None:
         shutil.rmtree(str(train_dir))
     train_dir.mkdir(exist_ok=True)
     for name, knp_str in train_list:
-        with (train_dir / f"{name}.knp").open("w") as f:
+        with (train_dir / f"{name}.knp").open("w", encoding="utf-8") as f:
             f.write(f"{knp_str}\n")
 
     valid_dir: Path = output_dir / "valid"
@@ -138,7 +138,7 @@ def main() -> None:
         shutil.rmtree(str(valid_dir))
     valid_dir.mkdir(exist_ok=True)
     for name, knp_str in valid_list:
-        with (valid_dir / f"{name}.knp").open("w") as f:
+        with (valid_dir / f"{name}.knp").open("w", encoding="utf-8") as f:
             f.write(f"{knp_str}\n")
 
     test_dir: Path = output_dir / "test"
@@ -146,7 +146,7 @@ def main() -> None:
         shutil.rmtree(str(test_dir))
     test_dir.mkdir(exist_ok=True)
     for name, knp_str in test_list:
-        with (test_dir / f"{name}.knp").open("w") as f:
+        with (test_dir / f"{name}.knp").open("w", encoding="utf-8") as f:
             f.write(f"{knp_str}\n")
 
     print(f"train: {len(train_list)}")

--- a/scripts/preprocessors/preprocess_reading.py
+++ b/scripts/preprocessors/preprocess_reading.py
@@ -26,7 +26,7 @@ def main() -> None:
     reading_counter: dict[str, int] = Counter()
     for path in args.in_dir.glob("**/*.knp"):
         logger.info(f"processing {path}")
-        with path.open() as f:
+        with path.open(encoding="utf-8") as f:
             document = Document.from_knp(f.read())
         try:
             for reading in reading_aligner.align(document.morphemes):

--- a/scripts/preprocessors/preprocess_typo.py
+++ b/scripts/preprocessors/preprocess_typo.py
@@ -132,7 +132,7 @@ def convert_components_into_tags(components: list[Component], length: int) -> tu
 def load_examples(in_dir: Path, split: str) -> tuple[dict[str, list[dict[str, str]]], list[dict[str, str]]]:
     category2examples: dict[str, list[dict[str, str]]] = defaultdict(list)
     other_examples: list[dict[str, str]] = []
-    with (in_dir / f"{split}.jsonl").open() as f:
+    with (in_dir / f"{split}.jsonl").open(encoding="utf-8") as f:
         for line in f:
             example: dict = json.loads(line)
             normalize_example(example)
@@ -172,17 +172,17 @@ def save_examples(
         random.shuffle(train_examples)
         train_dir: Path = out_dir / split
         train_dir.mkdir(parents=True, exist_ok=True)
-        with (train_dir / f"{split}.jsonl").open(mode="w") as f:
+        with (train_dir / f"{split}.jsonl").open(mode="w", encoding="utf-8") as f:
             f.write("\n".join(json.dumps(e, ensure_ascii=False) for e in train_examples) + "\n")
 
         valid_dir: Path = out_dir / "valid"
         valid_dir.mkdir(parents=True, exist_ok=True)
-        with (valid_dir / "valid.jsonl").open(mode="w") as f:
+        with (valid_dir / "valid.jsonl").open(mode="w", encoding="utf-8") as f:
             f.write("\n".join(json.dumps(e, ensure_ascii=False) for e in valid_examples) + "\n")
     elif split == "test":
         test_dir: Path = out_dir / split
         test_dir.mkdir(parents=True, exist_ok=True)
-        with (test_dir / f"{split}.jsonl").open(mode="w") as f:
+        with (test_dir / f"{split}.jsonl").open(mode="w", encoding="utf-8") as f:
             f.write("\n".join(json.dumps(e, ensure_ascii=False) for e in other_examples) + "\n")
     else:
         raise ValueError("invalid split")
@@ -190,7 +190,7 @@ def save_examples(
 
 def build_multi_char_vocab(out_dir: Path) -> None:
     multi_char_vocab: list[str] = []
-    with (out_dir / "train" / "train.jsonl").open() as f:
+    with (out_dir / "train" / "train.jsonl").open(encoding="utf-8") as f:
         for line in f:
             train_example: dict = json.loads(line)
             for ins_tag in train_example["ins_tags"]:
@@ -202,7 +202,7 @@ def build_multi_char_vocab(out_dir: Path) -> None:
 
     multi_char_vocab_counter = Counter(multi_char_vocab)
 
-    with (out_dir / "multi_char_vocab.txt").open(mode="w") as f:
+    with (out_dir / "multi_char_vocab.txt").open(mode="w", encoding="utf-8") as f:
         for vocab, count in multi_char_vocab_counter.most_common():
             if count > 1:
                 f.write(f"{vocab}\n")

--- a/scripts/view_seq2seq_results.py
+++ b/scripts/view_seq2seq_results.py
@@ -98,9 +98,9 @@ class MorphologicalAnalysisScorer:
         self.sys_sentences: list[Sentence] = sys_sentences
         self.gold_sentences: list[Sentence] = gold_sentences
 
-        with (dataset_dir / Path("canon/info.json")).open() as f:
+        with (dataset_dir / Path("canon/info.json")).open(encoding="utf-8") as f:
             self.canon_info: dict[str, dict[str, dict[str, str]]] = json.load(f)
-        with (dataset_dir / Path("norm/info.json")).open() as f:
+        with (dataset_dir / Path("norm/info.json")).open(encoding="utf-8") as f:
             self.norm_info: dict[str, dict[str, dict[str, str]]] = json.load(f)
 
         self.num_diff_texts: int = 0
@@ -326,7 +326,7 @@ def main() -> None:
     jumanpp = Jumanpp()
 
     sid_to_seq2seq_sent: dict[str, Sentence] = dict()
-    with Path(args.seq2seq_file).open() as f:
+    with Path(args.seq2seq_file).open(encoding="utf-8") as f:
         seq2seq_document: Document = Document.from_jumanpp(f.read())
         for sentence in seq2seq_document.sentences:
             sid_to_seq2seq_sent[sentence.sid] = sentence
@@ -340,7 +340,7 @@ def main() -> None:
 
         gold_paths: list[Path] = list(Path(f"{args.dataset_dir}/{corpus}/test").glob("*.knp"))
         for gold_path in gold_paths:
-            with gold_path.open() as f:
+            with gold_path.open(encoding="utf-8") as f:
                 gold_document: Document = Document.from_knp(f.read())
             for gold_sentence in gold_document.sentences:
                 sid_to_gold_sent[gold_sentence.sid] = gold_sentence
@@ -348,9 +348,9 @@ def main() -> None:
                 juman_path: Path = juman_dir / f"{gold_path.stem}_{gold_sentence.sid}.jumanpp"
                 if not juman_path.exists():
                     juman_sentence: Sentence = jumanpp.apply_to_sentence(gold_sentence)
-                    with juman_path.open("w") as f:
+                    with juman_path.open("w", encoding="utf-8") as f:
                         f.write(juman_sentence.to_jumanpp())
-                with juman_path.open() as f:
+                with juman_path.open(encoding="utf-8") as f:
                     juman_sentence = Sentence.from_jumanpp(f.read())
                     sid_to_juman_sent[gold_sentence.sid] = juman_sentence
 

--- a/tests/callbacks/test_char_module_writer.py
+++ b/tests/callbacks/test_char_module_writer.py
@@ -113,7 +113,7 @@ def test_write_on_batch_end(char_tokenizer: PreTrainedTokenizerBase) -> None:
         writer = CharModuleWriter(destination=tmp_dir / Path("char_prediction.juman"))
         writer.write_on_batch_end(trainer, ..., prediction, None, ..., 0, 0)
         assert isinstance(writer.destination, Path), "destination isn't set"
-        assert writer.destination.read_text() == dedent(
+        assert writer.destination.read_text(encoding="utf-8") == dedent(
             f"""\
             # S-ID:{doc_id_prefix}-0-1 kwja:{version("kwja")}
             花咲 _ 花咲 未定義語 15 その他 1 * 0 * 0

--- a/tests/callbacks/test_seq2seq_module_writer.py
+++ b/tests/callbacks/test_seq2seq_module_writer.py
@@ -57,7 +57,7 @@ def test_write_on_batch_end(seq2seq_tokenizer: PreTrainedTokenizerFast) -> None:
         EOS
         """
     )
-    with tempfile.NamedTemporaryFile("wt", delete=False) as juman_file:
+    with tempfile.NamedTemporaryFile("wt", delete=False, encoding="utf-8") as juman_file:
         juman_file.write(juman_text)
         juman_file_path = Path(juman_file.name)
 
@@ -107,7 +107,7 @@ def test_write_on_batch_end(seq2seq_tokenizer: PreTrainedTokenizerFast) -> None:
         )
         writer.write_on_batch_end(trainer, ..., prediction, None, ..., 0, 0)
         assert isinstance(writer.destination, Path), "destination isn't set"
-        assert writer.destination.read_text() == dedent(
+        assert writer.destination.read_text(encoding="utf-8") == dedent(
             f"""\
             # S-ID:{doc_id_prefix}-0-1 kwja:{version("kwja")}
             太郎 たろう 太郎 未定義語 15 その他 1 * 0 * 0 "代表表記:太郎/たろう"

--- a/tests/callbacks/test_typo_module_writer.py
+++ b/tests/callbacks/test_typo_module_writer.py
@@ -122,4 +122,4 @@ def test_write_on_batch_end(typo_tokenizer: PreTrainedTokenizerBase) -> None:
             writer = TypoModuleWriter(confidence_threshold, typo_tokenizer, destination=destination)
             writer.write_on_batch_end(trainer, ..., prediction, None, ..., 0, 0)
             assert isinstance(writer.destination, Path), "destination isn't set"
-            assert writer.destination.read_text() == expected_text
+            assert writer.destination.read_text(encoding="utf-8") == expected_text

--- a/tests/callbacks/test_word_module_writer.py
+++ b/tests/callbacks/test_word_module_writer.py
@@ -99,7 +99,7 @@ def test_write_on_batch_end(word_tokenizer: PreTrainedTokenizerBase, dataset_kwa
         EOS
         """
     )
-    with tempfile.NamedTemporaryFile("wt", delete=False) as juman_file:
+    with tempfile.NamedTemporaryFile("wt", delete=False, encoding="utf-8") as juman_file:
         juman_file.write(juman_text)
         juman_file_path = Path(juman_file.name)
 
@@ -390,7 +390,7 @@ def test_write_on_batch_end(word_tokenizer: PreTrainedTokenizerBase, dataset_kwa
         writer.jumandic = build_dummy_jumandic()
         writer.write_on_batch_end(trainer, module, prediction, None, ..., 0, 0)
         assert isinstance(writer.destination, Path), "destination isn't set"
-        assert writer.destination.read_text() == dedent(
+        assert writer.destination.read_text(encoding="utf-8") == dedent(
             f"""\
             # S-ID:{doc_id_prefix}-0-0 kwja:{version("kwja")}
             * 1P

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -122,7 +122,7 @@ def test_normalization_and_char_module(text: str, output: str) -> None:
 
 
 def test_file_input() -> None:
-    with tempfile.NamedTemporaryFile("wt", delete=False) as f:
+    with tempfile.NamedTemporaryFile("wt", delete=False, encoding="utf-8") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -157,7 +157,7 @@ def test_interactive_mode(text: str) -> None:
 
 
 def test_sanity() -> None:
-    with tempfile.NamedTemporaryFile("wt", delete=False) as f:
+    with tempfile.NamedTemporaryFile("wt", delete=False, encoding="utf-8") as f:
         f.write(
             textwrap.dedent(
                 """\

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -16,7 +16,7 @@ def test_download_checkpoint_downloads_from_huggingface_hub(tmp_path: Path, monk
         assert isinstance(local_dir, Path)
         assert isinstance(filename, str)
         path = local_dir / filename
-        path.write_text("checkpoint")
+        path.write_text("checkpoint", encoding="utf-8")
         return str(path)
 
     monkeypatch.setattr(utils, "hf_hub_download", fake_hf_hub_download)
@@ -39,7 +39,7 @@ def test_download_checkpoint_downloads_from_huggingface_hub(tmp_path: Path, monk
 
 def test_download_checkpoint_skips_existing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     checkpoint_path = tmp_path / "char_deberta-v2-base-wwm.ckpt"
-    checkpoint_path.write_text("checkpoint")
+    checkpoint_path.write_text("checkpoint", encoding="utf-8")
 
     def fake_hf_hub_download(**_kwargs: object) -> str:
         raise AssertionError("hf_hub_download should not be called")
@@ -65,7 +65,7 @@ def test_hf_hub_download_disables_progress_temporarily(tmp_path: Path, monkeypat
         assert isinstance(local_dir, Path)
         assert isinstance(filename, str)
         path = local_dir / filename
-        path.write_text("checkpoint")
+        path.write_text("checkpoint", encoding="utf-8")
         return str(path)
 
     monkeypatch.setattr(utils, "hf_hub_download", fake_hf_hub_download)

--- a/tests/datamodule/datasets/test_seq2seq_inference_dataset.py
+++ b/tests/datamodule/datasets/test_seq2seq_inference_dataset.py
@@ -43,7 +43,7 @@ def test_len(seq2seq_tokenizer: PreTrainedTokenizerFast) -> None:
         EOS
         """
     )
-    with tempfile.NamedTemporaryFile("wt", delete=False) as juman_file:
+    with tempfile.NamedTemporaryFile("wt", delete=False, encoding="utf-8") as juman_file:
         juman_file.write(juman_text)
         juman_file_path = Path(juman_file.name)
 
@@ -95,7 +95,7 @@ def test_getitem(seq2seq_tokenizer: PreTrainedTokenizerFast) -> None:
         EOS
         """
     )
-    with tempfile.NamedTemporaryFile("wt", delete=False) as juman_file:
+    with tempfile.NamedTemporaryFile("wt", delete=False, encoding="utf-8") as juman_file:
         juman_file.write(juman_text)
         juman_file_path = Path(juman_file.name)
 

--- a/tests/datamodule/datasets/test_word_dataset.py
+++ b/tests/datamodule/datasets/test_word_dataset.py
@@ -78,7 +78,7 @@ def test_encode(data_dir: Path, word_tokenizer: PreTrainedTokenizerBase, dataset
     max_seq_length = 64
     document_split_stride = 1
     dataset = WordDataset(str(path), word_tokenizer, max_seq_length, document_split_stride, **dataset_kwargs)
-    dataset.examples[1].load_discourse_document(Document.from_knp(path.joinpath("1.knp").read_text()))
+    dataset.examples[1].load_discourse_document(Document.from_knp(path.joinpath("1.knp").read_text(encoding="utf-8")))
     num_examples = len(dataset)
 
     reading_labels = torch.full((num_examples, max_seq_length), IGNORE_INDEX, dtype=torch.long)
@@ -367,7 +367,7 @@ def test_split_into_words_encode(
     dataset = WordDataset(
         str(path), split_into_words_word_tokenizer, max_seq_length, document_split_stride, **dataset_kwargs
     )
-    dataset.examples[1].load_discourse_document(Document.from_knp(path.joinpath("1.knp").read_text()))
+    dataset.examples[1].load_discourse_document(Document.from_knp(path.joinpath("1.knp").read_text(encoding="utf-8")))
     num_examples = len(dataset)
 
     reading_labels = torch.full((num_examples, max_seq_length), IGNORE_INDEX, dtype=torch.long)

--- a/tests/datamodule/datasets/test_word_inference_dataset.py
+++ b/tests/datamodule/datasets/test_word_inference_dataset.py
@@ -28,7 +28,7 @@ def test_len(word_tokenizer: PreTrainedTokenizerBase, dataset_kwargs: dict[str, 
         EOS
         """
     )
-    with tempfile.NamedTemporaryFile("wt", delete=False) as juman_file:
+    with tempfile.NamedTemporaryFile("wt", delete=False, encoding="utf-8") as juman_file:
         juman_file.write(juman_text)
         juman_file_path = Path(juman_file.name)
 
@@ -60,7 +60,7 @@ def test_len_multi_doc(word_tokenizer: PreTrainedTokenizerBase, dataset_kwargs: 
         EOS
         """
     )
-    with tempfile.NamedTemporaryFile("wt", delete=False) as juman_file:
+    with tempfile.NamedTemporaryFile("wt", delete=False, encoding="utf-8") as juman_file:
         juman_file.write(juman_text)
         juman_file_path = Path(juman_file.name)
 
@@ -86,7 +86,7 @@ def test_getitem(word_tokenizer: PreTrainedTokenizerBase, dataset_kwargs: dict[s
         EOS
         """
     )
-    with tempfile.NamedTemporaryFile("wt", delete=False) as juman_file:
+    with tempfile.NamedTemporaryFile("wt", delete=False, encoding="utf-8") as juman_file:
         juman_file.write(juman_text)
         juman_file_path = Path(juman_file.name)
 

--- a/tests/metrics/test_word_module_metric.py
+++ b/tests/metrics/test_word_module_metric.py
@@ -32,7 +32,7 @@ def test_word_module_metric(
     path = data_dir / "datasets" / "word_files"
     max_seq_length = 20
     dataset = WordDataset(str(path), word_tokenizer, max_seq_length, document_split_stride=1, **dataset_kwargs)
-    dataset.examples[1].load_discourse_document(Document.from_knp(path.joinpath("1.knp").read_text()))
+    dataset.examples[1].load_discourse_document(Document.from_knp(path.joinpath("1.knp").read_text(encoding="utf-8")))
     reading_id2reading = {v: k for k, v in dataset.reading2reading_id.items()}
     training_tasks = [
         WordTask.READING_PREDICTION,

--- a/tests/modules/components/test_logits_processor.py
+++ b/tests/modules/components/test_logits_processor.py
@@ -85,7 +85,7 @@ def test_get_target_property(data_dir: Path) -> None:
         reading_candidate_token_ids: list[int] = get_reading_candidate_token_ids(tokenizer)
         char2token_items: dict[str, dict[str, int]] = get_char2token_items(tokenizer)
         test_case_path: Path = data_dir / "modules" / "permitted_tokens.json"
-        with open(test_case_path) as f:
+        with open(test_case_path, encoding="utf-8") as f:
             test_cases = json.load(f)
         for test_case in test_cases.values():
             processor = SurfForcedDecodingLogitsProcessor(
@@ -217,7 +217,7 @@ def test_get_mask(data_dir: Path) -> None:
         all_tokens: set[str] = set(tokenizer.vocab.keys())
 
         test_case_path: Path = data_dir / "modules" / "permitted_tokens.json"
-        with open(test_case_path) as f:
+        with open(test_case_path, encoding="utf-8") as f:
             test_cases = json.load(f)
         for _k, test_case in test_cases.items():
             assert test_case["target_property"] in ["surf", "reading", "lemma", "canon", "init"]

--- a/tests/utils/test_seq2seq_format.py
+++ b/tests/utils/test_seq2seq_format.py
@@ -106,7 +106,7 @@ def test_get_surfs(data_dir: Path, seq2seq_tokenizer: PreTrainedTokenizerFast) -
     seq2seq_formatter = Seq2SeqFormatter(seq2seq_tokenizer)
     juman_dir: Path = data_dir / "modules" / "juman"
     for idx, path in enumerate(sorted(juman_dir.glob("*.juman"))):
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             sentence = Sentence.from_jumanpp(f.read())
             for morpheme in sentence.morphemes:
                 normalize_morpheme(morpheme)
@@ -145,7 +145,7 @@ def test_get_src_tokens(data_dir: Path, seq2seq_tokenizer: PreTrainedTokenizerFa
     seq2seq_formatter = Seq2SeqFormatter(seq2seq_tokenizer)
     juman_dir: Path = data_dir / "modules" / "juman"
     for idx, path in enumerate(sorted(juman_dir.glob("*.juman"))):
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             sentence = Sentence.from_jumanpp(f.read())
             for morpheme in sentence.morphemes:
                 normalize_morpheme(morpheme)
@@ -161,7 +161,7 @@ def test_get_tgt_tokens(data_dir: Path, seq2seq_tokenizer: PreTrainedTokenizerFa
     seq2seq_formatter = Seq2SeqFormatter(seq2seq_tokenizer)
     juman_dir: Path = data_dir / "modules" / "juman"
     for idx, path in enumerate(sorted(juman_dir.glob("*.juman"))):
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             sentence = Sentence.from_jumanpp(f.read())
             for morpheme in sentence.morphemes:
                 normalize_morpheme(morpheme)
@@ -181,7 +181,7 @@ def test_format_to_sent(data_dir: Path, seq2seq_tokenizer: PreTrainedTokenizerFa
     seq2seq_formatter = Seq2SeqFormatter(seq2seq_tokenizer)
     juman_dir: Path = data_dir / "modules" / "juman"
     for idx, path in enumerate(sorted(juman_dir.glob("*.juman"))):
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             expected_sentence = Sentence.from_jumanpp(f.read())
             for morpheme in expected_sentence.morphemes:
                 normalize_morpheme(morpheme)


### PR DESCRIPTION
## What

Follow-up to #251, which fixed unspecified-encoding text file I/O in the library code. The same pattern remained outside `src/`:

- **tests/: 16 sites** reading text files with the locale encoding (`Path.read_text()` / `open()` without `encoding`). Since #251 the module writers correctly write UTF-8, so on Windows whose default codec is not UTF-8 (e.g. cp932 on Japanese Windows) the tests read that output back with the wrong codec and the suite fails deterministically (`UnicodeDecodeError` in `test_char_module_writer`, `test_typo_module_writer`, etc.).
- **tests/: 9 sites** writing test input files via `tempfile.NamedTemporaryFile("wt")` without `encoding`. These write cp932 input that the library then (correctly) reads as UTF-8 — the mirror image of the above (`test_cli`, `test_word_inference_dataset`, etc.).
- **scripts/: 35 sites** of the same pattern, fixed for consistency, as hkiyomaru/jinf#2 did for its scripts.

All affected files always contain UTF-8 text, so behavior on Linux/macOS is unchanged — the arguments only pin down what was already assumed.

## Verification

- Full test suite passes on Japanese Windows 11 (locale cp932, `PYTHONUTF8` **unset**): **1390 passed, 0 failed**. Before this change, 40+ tests fail on the same machine.
- `ruff check` / `ruff format --check` (v0.16.1, same as pre-commit): clean.

## Known limitation

This PR alone does not make the suite fully green on Japanese Windows from a fresh `uv sync`: `jinf` 1.0.4 (the latest release on PyPI) still crashes with `UnicodeDecodeError` when loading its bundled dictionaries (`jinf/jinf.py:14`), which takes down `WordModuleWriter` construction and everything that depends on it. The fix was merged as hkiyomaru/jinf#2 but has not been released yet. My green run above was obtained with a jinf build that includes that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)