### PR TITLE
Keep models on the device across predictions

### DIFF
--- a/src/kwja/cli/cli.py
+++ b/src/kwja/cli/cli.py
@@ -46,10 +46,17 @@ class _KeepModelOnDeviceStrategy(SingleDeviceStrategy):
     """A single-device strategy whose teardown leaves the model on the device.
 
     Trainer.predict() tears its strategy down after every call, and the default
-    teardown moves the model back to the CPU. The CLI keeps the modules loaded
-    and calls predict() once per input in interactive mode, so on an accelerator
-    every prediction would otherwise pay a full model round-trip between the CPU
-    and the device.
+    teardown moves the model back to the CPU. Interactive mode keeps the modules
+    loaded and calls predict() once per input, so on an accelerator every
+    prediction would otherwise pay a full model round-trip between the CPU and
+    the device.
+
+    This is opt-in because retaining the model is only safe when it is going to
+    be reused. Batch mode drops each module once its task is done, and Lightning
+    objects take part in reference cycles, so the module can outlive
+    `delete_module_and_trainer()` until the cyclic collector runs; moving it back
+    to the CPU there keeps the peak device memory down while the next module and
+    checkpoint are allocated.
     """
 
     def __init__(self, device: torch.device) -> None:
@@ -81,7 +88,7 @@ class BaseModuleProcessor(ABC):
         self.module: L.LightningModule | None = None
         self.trainer: L.Trainer | None = None
 
-    def load(self, **writer_kwargs) -> None:
+    def load(self, keep_model_on_device: bool = False, **writer_kwargs) -> None:
         self.module = self._load_module()
         if self.config.torch_compile is True:
             self.module: L.LightningModule = torch.compile(self.module)  # ty: ignore[invalid-assignment]
@@ -101,7 +108,7 @@ class BaseModuleProcessor(ABC):
                 ),
                 hydra.utils.instantiate(self.module.hparams.callbacks.progress_bar),  # type: ignore[union-attr]
             ],
-            strategy=_KeepModelOnDeviceStrategy(device=self.device),
+            strategy=_KeepModelOnDeviceStrategy(device=self.device) if keep_model_on_device else "auto",
             accelerator=self.accelerator,
             devices=1,
         )
@@ -220,8 +227,12 @@ class WordModuleProcessor(BaseModuleProcessor):
         super().__init__(config, batch_size)
         self.from_seq2seq = from_seq2seq
 
-    def load(self, **writer_kwargs) -> None:
-        super().load(preserve_reading_lemma_canon=self.from_seq2seq, **writer_kwargs)
+    def load(self, keep_model_on_device: bool = False, **writer_kwargs) -> None:
+        super().load(
+            keep_model_on_device=keep_model_on_device,
+            preserve_reading_lemma_canon=self.from_seq2seq,
+            **writer_kwargs,
+        )
 
     def _load_module(self) -> L.LightningModule:
         logger.info("Loading word module")
@@ -257,8 +268,10 @@ class CLIProcessor:
         self.processors: list[BaseModuleProcessor] = [self._task2processors[task] for task in tasks]
 
     def load_all_modules(self) -> None:
+        # Only interactive mode loads every module up front and reuses them, so this is
+        # the one place where retaining the models on the device is worthwhile.
         for processor in self.processors:
-            processor.load()
+            processor.load(keep_model_on_device=True)
 
     def refresh(self) -> None:
         self.initial_destination.unlink(missing_ok=True)

--- a/src/kwja/cli/cli.py
+++ b/src/kwja/cli/cli.py
@@ -13,6 +13,7 @@ import hydra
 import lightning as L
 import torch
 import typer
+from lightning.pytorch.strategies import SingleDeviceStrategy
 from lightning.pytorch.trainer.states import TrainerFn
 from rhoknp import Document, Sentence
 from rhoknp.utils.reader import chunk_by_document, chunk_by_sentence
@@ -39,6 +40,32 @@ class InputFormat(str, Enum):
     RAW = "raw"
     JUMANPP = "jumanpp"
     KNP = "knp"
+
+
+class _KeepModelOnDeviceStrategy(SingleDeviceStrategy):
+    """A single-device strategy whose teardown leaves the model on the device.
+
+    Trainer.predict() tears its strategy down after every call, and the default
+    teardown moves the model back to the CPU. The CLI keeps the modules loaded
+    and calls predict() once per input in interactive mode, so on an accelerator
+    every prediction would otherwise pay a full model round-trip between the CPU
+    and the device.
+    """
+
+    def __init__(self, device: torch.device) -> None:
+        if device.type != "cpu" and device.index is None:
+            # SingleDeviceStrategy requires an indexed device ("cuda" alone is
+            # rejected by torch.cuda.set_device); the CLI always uses one device.
+            device = torch.device(device.type, 0)
+        super().__init__(device=device)
+
+    def teardown(self) -> None:
+        # Strategy.teardown() minus lightning_module.cpu(); prediction has no
+        # optimizers, so moving them to the CPU is not needed either.
+        self.precision_plugin.teardown()
+        assert self.accelerator is not None
+        self.accelerator.teardown()
+        self.checkpoint_io.teardown()
 
 
 class BaseModuleProcessor(ABC):
@@ -74,6 +101,7 @@ class BaseModuleProcessor(ABC):
                 ),
                 hydra.utils.instantiate(self.module.hparams.callbacks.progress_bar),  # type: ignore[union-attr]
             ],
+            strategy=_KeepModelOnDeviceStrategy(device=self.device),
             accelerator=self.accelerator,
             devices=1,
         )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,7 +9,8 @@ from rhoknp import Document
 from rhoknp.utils.reader import chunk_by_document
 from typer.testing import CliRunner
 
-from kwja.cli.cli import app
+from kwja.cli.cli import CharModuleProcessor, CLIProcessor, _KeepModelOnDeviceStrategy, app
+from kwja.cli.config import CLIConfig, Device, ModelSize
 
 runner = CliRunner()
 
@@ -360,3 +361,34 @@ def test_input_format_knp(tasks: str) -> None:
         assert sentences[0].sent_id == "test-0"
         assert sentences[1].text == "こんばんは。"
         assert sentences[1].sent_id == "test-1"
+
+
+def test_batch_mode_uses_the_default_strategy() -> None:
+    """Batch mode drops each module when its task is done, so it must not retain models."""
+    processor = CharModuleProcessor(CLIConfig(model_size=ModelSize.TINY, device=Device.CPU), batch_size=1)
+    processor.load()
+    assert not isinstance(processor.trainer.strategy, _KeepModelOnDeviceStrategy)
+
+
+def test_interactive_mode_keeps_models_on_the_device() -> None:
+    """Interactive mode reuses the same modules, so it opts into retaining them."""
+    processor = CLIProcessor(CLIConfig(model_size=ModelSize.TINY, device=Device.CPU), ["char"])
+    processor.load_all_modules()
+    for module_processor in processor.processors:
+        assert isinstance(module_processor.trainer.strategy, _KeepModelOnDeviceStrategy)
+
+
+def test_interactive_mode_repeated_predictions() -> None:
+    """Predicting repeatedly with retained modules must keep producing the same output."""
+    processor = CLIProcessor(CLIConfig(model_size=ModelSize.TINY, device=Device.CPU), ["char"])
+    processor.load_all_modules()
+    outputs = []
+    for _ in range(3):
+        processor.refresh()
+        output = processor.run([Document.from_raw_text("こんにちは。")], interactive=True)
+        # Sentence ids are derived from the current time, so normalize them away.
+        outputs.append(re.sub(r"# S-ID:\S+", "# S-ID:", output))
+    processor.refresh()
+    assert outputs[0] != ""
+    assert outputs[1] == outputs[0]
+    assert outputs[2] == outputs[0]


### PR DESCRIPTION
## What

`Trainer.predict()` tears its strategy down after every call, and Lightning's default `Strategy.teardown()` unconditionally moves the model back to the CPU. The CLI keeps its modules loaded and calls `predict()` once per input in interactive mode, so on an accelerator **every prediction pays a full model round-trip between the CPU and the device**. With the base model on CUDA, `model_to_device` costs a measured ~245ms per predict call and per module — ~490ms per input for `tasks=char,word` — which made GPU inference *slower* than CPU for short inputs.

This PR gives the CLI a `SingleDeviceStrategy` subclass whose teardown skips the `lightning_module.cpu()` move (prediction has no optimizers, so moving those is not needed either). CPU behavior is unchanged — `.cpu()` was a no-op there.

## Measurements

RTX 5060 Ti, base model, `tasks=char,word`, interactive prediction, `HF_HUB_OFFLINE=1`, median of 5+ runs:

| input | CPU | CUDA before | CUDA after |
|---|---|---|---|
| 1 sentence (17 chars) | 345 ms | 582 ms | **138 ms** |
| 4 sentences | 477 ms | 630 ms | **160 ms** |
| 20 sentences | 1314 ms | 778 ms | **320 ms** |
| 100 sentences | 41.6 s | 9.2 s | **9.1 s** |

Before the fix, CUDA lost to CPU below roughly 8 sentences per input; after it, CUDA wins at every input size.

## Verification

- Output on CUDA is **byte-identical** to CPU on an 8-case verification set (inverted word order, cross-sentence zero anaphora, indirect passives, multi-sentence documents), after normalizing the timestamp-derived sentence ids.
- Interactive-mode and batch-mode CLI tests pass; the full suite was run locally on Japanese Windows and the only failures are the pre-existing locale-encoding issues addressed by #253 (unrelated to this change).
- `ruff check` / `ruff format --check` (v0.16.1): clean.
- The strategy normalizes an index-less device (`cuda` → `cuda:0`), since `torch.cuda.set_device` rejects `torch.device("cuda")` without an index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)