### PR TITLE
Build the pairwise word selection tensors in slices

### DIFF
--- a/src/kwja/modules/components/head.py
+++ b/src/kwja/modules/components/head.py
@@ -3,6 +3,35 @@ import math
 import torch
 from torch import nn
 
+# The pairwise hidden state built by the word selection heads below is O(seq^2 * rel * hid):
+# 1.8 GB for seq=256 with the base model, which dominates peak device memory during
+# prediction. Building it in slices of the source dimension bounds that intermediate.
+#
+# The reduction that produces the logits runs over the hidden dimension, which is never
+# split, so the arithmetic is unchanged -- only the order in which rows are filled in.
+# The results are bit-identical at the dimensions the models actually use, on CPU and on
+# CUDA alike. They can differ in the last bits at small dimensions, because the matrix
+# multiplication picks its blocking from the operand shape; the tests cover that case and
+# assert that it never moves an argmax.
+_CHUNK_TARGET_BYTES = 32 * 1024 * 1024
+
+
+def _source_chunk_size(source: torch.Tensor, chunking_allowed: bool) -> int:
+    """Number of source positions to expand at once, or the full length to disable chunking.
+
+    Callers disallow chunking while autograd is recording, because every slice would then be
+    kept alive for the backward pass and there would be nothing to save, and while the module
+    is in training mode, because dropout would draw its masks per slice rather than once for
+    the whole pairwise tensor.
+    """
+    seq_length = source.size(1)
+    if not chunking_allowed:
+        return seq_length
+    bytes_per_source_position = source[:, :1].numel() * seq_length * source.element_size()
+    if bytes_per_source_position == 0:
+        return seq_length
+    return max(1, min(seq_length, _CHUNK_TARGET_BYTES // bytes_per_source_position))
+
 
 class SequenceLabelingHead(nn.Sequential):
     def __init__(self, num_labels: int, hidden_size: int, hidden_dropout_prob: float) -> None:
@@ -59,8 +88,27 @@ class WordSelectionHead(nn.Module):
     def forward(self, pooled: torch.Tensor) -> torch.Tensor:
         h_source = self.l_source(pooled)  # (b, seq, hid)
         h_target = self.l_target(pooled)  # (b, seq, hid)
-        hidden = self.dropout(self.activation(h_source.unsqueeze(2) + h_target.unsqueeze(1)))  # (b, seq, seq, hid)
-        return self.output_layer(hidden)  # (b, seq, seq, label)
+        chunk_size = _source_chunk_size(h_source, chunking_allowed=not self.training and not torch.is_grad_enabled())
+        if chunk_size >= h_source.size(1):
+            hidden = self.dropout(self.activation(h_source.unsqueeze(2) + h_target.unsqueeze(1)))  # (b, seq, seq, hid)
+            return self.output_layer(hidden)  # (b, seq, seq, label)
+        return self._forward_chunked(h_source, h_target, chunk_size)
+
+    def _forward_chunked(self, h_source: torch.Tensor, h_target: torch.Tensor, chunk_size: int) -> torch.Tensor:
+        batch_size, seq_length = h_source.size(0), h_source.size(1)
+        logits = torch.empty(
+            (batch_size, seq_length, seq_length, self.output_layer.out_features),
+            device=h_source.device,
+            dtype=h_source.dtype,
+        )
+        unsqueezed_target = h_target.unsqueeze(1)  # (b, 1, seq, hid)
+        for start in range(0, seq_length, chunk_size):
+            stop = min(start + chunk_size, seq_length)
+            hidden = self.dropout(
+                self.activation(h_source[:, start:stop].unsqueeze(2) + unsqueezed_target)
+            )  # (b, chunk, seq, hid)
+            logits[:, start:stop] = self.output_layer(hidden)
+        return logits
 
 
 class RelationWiseWordSelectionHead(nn.Module):
@@ -77,8 +125,28 @@ class RelationWiseWordSelectionHead(nn.Module):
         batch_size, seq_length, hidden_size = pooled.size()
         h_source = self.l_source(pooled).view(batch_size, seq_length, -1, hidden_size)  # (b, seq, rel, hid)
         h_target = self.l_target(pooled).view(batch_size, seq_length, -1, hidden_size)  # (b, seq, rel, hid)
-        hidden = self.dropout(self.activation(h_source.unsqueeze(2) + h_target.unsqueeze(1)))  # (b, seq, seq, rel, hid)
-        return torch.einsum("bstlh,hl->bstl", hidden, self.classifier_weight)  # (b, seq, seq, rel)
+        chunk_size = _source_chunk_size(h_source, chunking_allowed=not self.training and not torch.is_grad_enabled())
+        if chunk_size >= seq_length:
+            hidden = self.dropout(
+                self.activation(h_source.unsqueeze(2) + h_target.unsqueeze(1))
+            )  # (b, seq, seq, rel, hid)
+            return torch.einsum("bstlh,hl->bstl", hidden, self.classifier_weight)  # (b, seq, seq, rel)
+        return self._forward_chunked(h_source, h_target, chunk_size)
+
+    def _forward_chunked(self, h_source: torch.Tensor, h_target: torch.Tensor, chunk_size: int) -> torch.Tensor:
+        batch_size, seq_length = h_source.size(0), h_source.size(1)
+        num_relations = self.classifier_weight.size(1)
+        logits = torch.empty(
+            (batch_size, seq_length, seq_length, num_relations), device=h_source.device, dtype=h_source.dtype
+        )
+        unsqueezed_target = h_target.unsqueeze(1)  # (b, 1, seq, rel, hid)
+        for start in range(0, seq_length, chunk_size):
+            stop = min(start + chunk_size, seq_length)
+            hidden = self.dropout(
+                self.activation(h_source[:, start:stop].unsqueeze(2) + unsqueezed_target)
+            )  # (b, chunk, seq, rel, hid)
+            logits[:, start:stop] = torch.einsum("bstlh,hl->bstl", hidden, self.classifier_weight)
+        return logits
 
 
 class LoRARelationWiseWordSelectionHead(nn.Module):
@@ -100,8 +168,26 @@ class LoRARelationWiseWordSelectionHead(nn.Module):
         delta_target_out = torch.einsum("bsh,hil->bsli", pooled, self.delta_target())  # (b, seq, rel, hid)
         source = h_source.unsqueeze(2) + delta_source_out  # (b, seq, rel, hid)
         target = h_target.unsqueeze(2) + delta_target_out  # (b, seq, rel, hid)
-        hidden = self.dropout(self.activation(source.unsqueeze(2) + target.unsqueeze(1)))  # (b, seq, seq, rel, hid)
-        return torch.einsum("bstlh,hl->bstl", hidden, self.classifier)  # (b, seq, seq, rel)
+        chunk_size = _source_chunk_size(source, chunking_allowed=not self.training and not torch.is_grad_enabled())
+        if chunk_size >= source.size(1):
+            hidden = self.dropout(self.activation(source.unsqueeze(2) + target.unsqueeze(1)))  # (b, seq, seq, rel, hid)
+            return torch.einsum("bstlh,hl->bstl", hidden, self.classifier)  # (b, seq, seq, rel)
+        return self._forward_chunked(source, target, chunk_size)
+
+    def _forward_chunked(self, source: torch.Tensor, target: torch.Tensor, chunk_size: int) -> torch.Tensor:
+        batch_size, seq_length = source.size(0), source.size(1)
+        num_relations = self.classifier.size(1)
+        logits = torch.empty(
+            (batch_size, seq_length, seq_length, num_relations), device=source.device, dtype=source.dtype
+        )
+        unsqueezed_target = target.unsqueeze(1)  # (b, 1, seq, rel, hid)
+        for start in range(0, seq_length, chunk_size):
+            stop = min(start + chunk_size, seq_length)
+            hidden = self.dropout(
+                self.activation(source[:, start:stop].unsqueeze(2) + unsqueezed_target)
+            )  # (b, chunk, seq, rel, hid)
+            logits[:, start:stop] = torch.einsum("bstlh,hl->bstl", hidden, self.classifier)
+        return logits
 
 
 class LoRADelta(nn.Module):

--- a/tests/modules/components/test_head.py
+++ b/tests/modules/components/test_head.py
@@ -1,11 +1,17 @@
+from collections.abc import Callable
+
 import pytest
 import torch
+from torch import nn
 
+import kwja.modules.components.head as head_module
 from kwja.modules.components.head import (
+    LoRARelationWiseWordSelectionHead,
     LoRASequenceMultiLabelingHead,
     RelationWiseWordSelectionHead,
     SequenceLabelingHead,
     WordSelectionHead,
+    _source_chunk_size,
 )
 
 
@@ -69,3 +75,93 @@ def test_relation_wise_word_selection_head(num_labels: int, hidden_size: int, hi
     input_ = torch.ones(batch_size, seq_length, hidden_size)
     output = head(input_)
     assert output.size() == (batch_size, seq_length, seq_length, num_labels)
+
+
+@pytest.mark.parametrize(
+    ("num_relations", "hidden_size", "hidden_dropout_prob", "rank"),
+    [
+        (5, 3, 0.0, 4),
+        (1, 2, 0.1, 2),
+    ],
+)
+def test_lora_relation_wise_word_selection_head(
+    num_relations: int, hidden_size: int, hidden_dropout_prob: float, rank: int
+) -> None:
+    head = LoRARelationWiseWordSelectionHead(num_relations, hidden_size, hidden_dropout_prob, rank=rank)
+    batch_size, seq_length = 2, 5
+    input_ = torch.ones(batch_size, seq_length, hidden_size)
+    output = head(input_)
+    assert output.size() == (batch_size, seq_length, seq_length, num_relations)
+
+
+def test_source_chunk_size_falls_back_to_the_full_length() -> None:
+    source = torch.zeros(2, 16, 8)
+    assert _source_chunk_size(source, chunking_allowed=False) == 16
+    assert _source_chunk_size(source, chunking_allowed=True) == 16  # fits in the target budget
+
+
+def test_source_chunk_size_is_at_least_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(head_module, "_CHUNK_TARGET_BYTES", 1)
+    source = torch.zeros(2, 16, 8)
+    assert _source_chunk_size(source, chunking_allowed=True) == 1
+
+
+def test_source_chunk_size_falls_back_when_the_source_is_degenerate() -> None:
+    # A source with no positions, or none to expand into, leaves nothing to divide by.
+    assert _source_chunk_size(torch.zeros(2, 0, 8), chunking_allowed=True) == 0
+    assert _source_chunk_size(torch.zeros(2, 16, 0), chunking_allowed=True) == 16
+
+
+@pytest.mark.parametrize(
+    "build_head",
+    [
+        lambda: WordSelectionHead(3, 8, 0.1),
+        lambda: RelationWiseWordSelectionHead(3, 8, 0.1),
+        lambda: LoRARelationWiseWordSelectionHead(3, 8, 0.1, rank=2),
+    ],
+    ids=["word_selection", "relation_wise_word_selection", "lora_relation_wise_word_selection"],
+)
+def test_chunked_forward_matches_the_unchunked_one(
+    build_head: Callable[[], nn.Module], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    torch.manual_seed(0)
+    head = build_head().eval()
+    input_ = torch.randn(2, 16, 8)
+    with torch.no_grad():
+        expected = head(input_)
+        monkeypatch.setattr(head_module, "_CHUNK_TARGET_BYTES", 512)
+        actual = head(input_)
+    # Chunking splits the source positions, never the hidden dimension the logits are reduced
+    # over, so the arithmetic is the same. The results can still differ in the last bits
+    # because the matrix multiplication picks its blocking from the operand shape.
+    torch.testing.assert_close(actual, expected)
+    assert torch.equal(actual.argmax(dim=-1), expected.argmax(dim=-1))
+
+
+@pytest.mark.parametrize(
+    "build_head",
+    [
+        lambda: WordSelectionHead(3, 8, 0.1),
+        lambda: RelationWiseWordSelectionHead(3, 8, 0.1),
+        lambda: LoRARelationWiseWordSelectionHead(3, 8, 0.1, rank=2),
+    ],
+    ids=["word_selection", "relation_wise_word_selection", "lora_relation_wise_word_selection"],
+)
+def test_training_and_autograd_keep_the_unchunked_path(
+    build_head: Callable[[], nn.Module], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(head_module, "_CHUNK_TARGET_BYTES", 1)
+    head = build_head()
+    input_ = torch.randn(2, 16, 8)
+
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("the chunked path must not run here")
+
+    monkeypatch.setattr(type(head), "_forward_chunked", fail)
+
+    head.train()
+    with torch.no_grad():
+        head(input_)  # dropout would draw one mask per slice
+
+    head.eval()
+    assert head(input_).requires_grad is True  # autograd would keep every slice alive


### PR DESCRIPTION
The word selection heads expand their inputs into a pairwise hidden state before
reducing it to logits:

```python
hidden = self.dropout(self.activation(h_source.unsqueeze(2) + h_target.unsqueeze(1)))
# (b, seq, seq, [rel,] hid)
```

That intermediate is O(seq^2 * rel * hid). With the base model (`hid=768`, `rel=9`) at
`seq=255` it is **1.8 GB**, and it is by far the largest allocation the word module makes.
Expanding a slice of the source positions at a time bounds it.

### Measurements

RTX 5060 Ti, base model, `tasks=char,word`, batch size 1, default caching allocator,
Japanese prose in one interactive prediction:

| sentences | peak allocated | peak reserved | time |
|---|---|---|---|
| 1 | 1300 -> 1300 MB | 1472 -> 1472 MB | chunking does not engage |
| 20 | 2675 -> 1349 MB | 3022 -> 1583 MB | 0.30 -> 0.27 s |
| 50 | 3511 -> 1361 MB | 10926 -> 1590 MB | 3.38 -> 3.30 s |
| 100 | 3485 -> 1361 MB | 8439 -> 1590 MB | 8.64 -> 8.05 s |

Per-head peaks at 50 sentences before the change: encoder 38 MB, dependency 277 MB,
**cohesion 2512 MB**, discourse 277 MB. The cohesion head alone is 72% of the peak.

Reserved memory falls the furthest because the collator trims each batch to its effective
length, so this tensor is requested at a handful of slightly different multi-GB sizes
(seq 243 to 255 for that input) and the caching allocator takes a fresh segment for each
of them. Forcing a constant `seq=256` drops reserved from 10926 MB to 5214 MB, which is
what confirmed the mechanism. Slicing removes the multi-GB requests altogether.

Prediction also gets slightly faster, since the intermediate no longer has to travel to
device memory and back.

As a side effect, `PYTORCH_CUDA_ALLOC_CONF=backend:cudaMallocAsync`, which I had been
using as a workaround, is no longer worth setting: with slicing the default allocator
peaks at 1590 MB and cudaMallocAsync at 1577 MB.

### Correctness

The reduction that produces the logits runs over the hidden dimension, which is never
split, so the arithmetic is unchanged. Only the order in which rows of the output are
filled in changes.

- The KNP output for three Aozora Bunko works at 100 and 300 sentences each
  (1.9 M characters) is identical before and after, on CUDA and on CPU.
- The logits are bit-identical at the dimensions the released checkpoints use, on both
  devices. At small toy dimensions they can differ by about 1e-7, because the matrix
  multiplication picks its blocking from the operand shape; the added test covers that
  case and asserts that no argmax moves.
- `uv run --frozen --no-dev --group test pytest`: 1403 passed (1393 before, 10 added).
  `ruff check` and `ruff format` clean.

### Scope

Chunking is skipped while autograd is recording, because every slice would then be kept
alive for the backward pass and there would be nothing to save, and while the module is in
training mode, because dropout would otherwise draw a mask per slice rather than once for
the whole tensor. **Training runs exactly the code it runs today**; only prediction takes
the new path.

The chunk size comes from a 32 MiB target, so short inputs never reach the branch at all
(the cohesion head starts slicing at seq >= 35, the dependency and discourse heads at
seq >= 105). I did not tune that constant. The goal is to bound the intermediate rather
than to hit an optimum, and I did not measure a difference between plausible values.

All three heads that build the pairwise tensor get the same treatment, including
`RelationWiseWordSelectionHead`, which no module currently instantiates. The measured
savings above come from the two that prediction actually runs.

### An earlier explanation of mine was wrong

I had described this growth as caching-allocator fragmentation in a comment on #255.
That was wrong, and I have corrected it there. The allocator statistics rule fragmentation
out: over the same prediction `num_alloc_retries` is 0 and peak `inactive_split_bytes` is
1147 MB, against a 7.4 GB gap between allocated and reserved. The reserved memory is not
full of holes; whole segments sit empty. The cause is the size of this one tensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
